### PR TITLE
Multiple monitors

### DIFF
--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/BasicMonitorOrchestrationService.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/BasicMonitorOrchestrationService.java
@@ -8,6 +8,7 @@ import io.github.cloudiator.monitoring.converter.MonitorToVisorMonitorConverter;
 import io.github.cloudiator.monitoring.models.DomainMonitorModel;
 import io.github.cloudiator.persistance.MonitorDomainRepository;
 import io.github.cloudiator.rest.model.Monitor;
+import io.github.cloudiator.rest.model.MonitoringTarget;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/BasicMonitorOrchestrationService.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/BasicMonitorOrchestrationService.java
@@ -25,7 +25,18 @@ public class BasicMonitorOrchestrationService implements MonitorOrchestrationSer
 
   @Override
   public DomainMonitorModel createMonitor(Monitor newMonitor) {
-    return monitorDomainRepository.addMonitor(newMonitor);
+    DomainMonitorModel result = null;
+    for (MonitoringTarget target : newMonitor.getTargets()) {
+      Monitor test = new Monitor().metric(
+          newMonitor.getMetric().concat("+++").concat(target.getType().name()).concat("+++")
+              .concat(target.getIdentifier()));
+      test.setTags(newMonitor.getTags());
+      test.setSensor(newMonitor.getSensor());
+      test.setSinks(newMonitor.getSinks());
+      test.setTargets(newMonitor.getTargets());
+      result = monitorDomainRepository.addMonitor(test);
+    }
+    return result;
   }
 
   @Override

--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/BasicMonitorOrchestrationService.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/BasicMonitorOrchestrationService.java
@@ -3,6 +3,7 @@ package io.github.cloudiator.monitoring.domain;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.inject.Inject;
+import com.google.protobuf.MapEntry;
 import io.github.cloudiator.monitoring.converter.MonitorToVisorMonitorConverter;
 
 import io.github.cloudiator.monitoring.models.DomainMonitorModel;
@@ -11,6 +12,7 @@ import io.github.cloudiator.rest.model.Monitor;
 import io.github.cloudiator.rest.model.MonitoringTarget;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class BasicMonitorOrchestrationService implements MonitorOrchestrationService {
@@ -30,10 +32,12 @@ public class BasicMonitorOrchestrationService implements MonitorOrchestrationSer
       Monitor test = new Monitor().metric(
           newMonitor.getMetric().concat("+++").concat(target.getType().name()).concat("+++")
               .concat(target.getIdentifier()));
-      test.setTags(newMonitor.getTags());
       test.setSensor(newMonitor.getSensor());
       test.setSinks(newMonitor.getSinks());
       test.setTargets(newMonitor.getTargets());
+      Map<String, String> tagtargets = newMonitor.getTags();
+      tagtargets.put(target.getType().name(), target.getIdentifier());
+      test.setTags(tagtargets);
       result = monitorDomainRepository.addMonitor(test);
     }
     return result;

--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/MonitorManagementService.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/MonitorManagementService.java
@@ -42,6 +42,30 @@ public class MonitorManagementService {
 
   @Transactional
   public DomainMonitorModel checkAndCreate(Monitor monitor) {
+    Boolean check = false;
+    Optional<DomainMonitorModel> dbMonitor = null;
+    for (MonitoringTarget mTarget : monitor.getTargets()) {
+      String dbMetric = new String(
+          monitor.getMetric() + "+++" + mTarget.getType().name() + "+++" + mTarget.getIdentifier());
+      //monitor.setMetric(dbMetric);
+      dbMonitor = monitorOrchestrationService
+          .getMonitor(dbMetric);
+      if (dbMonitor.isPresent()) {
+        check = true;
+        break;
+      }
+    }
+    //Optional<DomainMonitorModel> dbMonitor = monitorOrchestrationService.getMonitor(monitor.getMetric());
+    if (check) {
+      return null;
+    } else {
+      dbMonitor = Optional.of(monitorOrchestrationService.createMonitor(monitor));
+      return dbMonitor.get();
+    }
+  }
+
+  @Transactional
+  public DomainMonitorModel checkMonitor(Monitor monitor) {
     Optional<DomainMonitorModel> dbMonitor = monitorOrchestrationService
         .getMonitor(monitor.getMetric());
     if (dbMonitor.isPresent()) {
@@ -104,6 +128,7 @@ public class MonitorManagementService {
         newMonitor.getTargets(), newMonitor.getSensor(), newMonitor.getSinks(),
         newMonitor.getTags());
     LOGGER.debug("Handling " + newMonitor.getTargets().size() + " Targets");
+
     DomainMonitorModel requestedMonitor = checkAndCreate(newMonitor);
     LOGGER.debug("Monitor in DB created");
     if (requestedMonitor == null) {

--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/MonitorManagementService.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/MonitorManagementService.java
@@ -51,6 +51,7 @@ public class MonitorManagementService {
       dbMonitor = monitorOrchestrationService
           .getMonitor(dbMetric);
       if (dbMonitor.isPresent()) {
+        LOGGER.debug("found Monitor: " + dbMonitor.get());
         check = true;
         break;
       }
@@ -130,11 +131,11 @@ public class MonitorManagementService {
     LOGGER.debug("Handling " + newMonitor.getTargets().size() + " Targets");
 
     DomainMonitorModel requestedMonitor = checkAndCreate(newMonitor);
-    LOGGER.debug("Monitor in DB created");
+
     if (requestedMonitor == null) {
       throw new IllegalArgumentException("Monitor already exists.");
     }
-
+    LOGGER.debug("Monitor(s) in DB created");
     Integer count = 1;
     for (MonitoringTarget mTarget : domainMonitor.getTargets()) {
       LOGGER.debug("Handling Target " + count);

--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/messaging/CreateMonitorListener.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/messaging/CreateMonitorListener.java
@@ -39,14 +39,12 @@ public class CreateMonitorListener implements Runnable {
 
               Monitor contentMonitor = monitorConverter.applyBack(content.getNewmonitor());
 
-              System.out.println("\n Got this Monitor: " + contentMonitor);
-
               Monitor createdMonitor = monitorManagementService
                   .handleNewMonitor(content.getUserId(), contentMonitor);
 
               CreateMonitorResponse monitorResponse = CreateMonitorResponse.newBuilder()
                   .setMonitor(monitorConverter.apply(createdMonitor)).build();
-              System.out.println("This is my Response: " + monitorResponse);
+              LOGGER.debug(" CreateMonitorRequest responded ");
               messageInterface.reply(id, monitorResponse);
 
             } catch (IllegalArgumentException ie) {

--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/messaging/MonitorQueryListener.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/messaging/MonitorQueryListener.java
@@ -44,18 +44,7 @@ public class MonitorQueryListener implements Runnable {
               }
               MonitorQueryResponse result = responseBuilder.build();
 
-
-              /*
-              List<Monitor> updatedMonitors = monitorManagementService
-                  .monitorupdate(content.getUserId());
-              MonitorQueryResponse.Builder responseBuilder2 = MonitorQueryResponse.newBuilder();
-              for (Monitor monitor : updatedMonitors) {
-                responseBuilder2.addMonitor(monitorConverter.apply(monitor));
-              }
-              MonitorQueryResponse result2 = responseBuilder2.build();
-              */
-
-              System.out.println("Sending result: " + result);
+              LOGGER.debug("Sending response for MonitorQueryRequest ");
               messageInterface.reply(id, result);
             } catch (Exception e) {
               LOGGER.error("Error while searching for Monitors. ", e);

--- a/monitoringagent/src/main/java/io/github/cloudiator/persistance/MonitorDomainRepository.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/persistance/MonitorDomainRepository.java
@@ -140,18 +140,22 @@ public class MonitorDomainRepository {
      *Save all Monitors
      * for every MonitorTarget one Monitor is added in DB
      */
-
+    /*
     for (TargetModel targetModel : monitorModel.getTargets()) {
       LOGGER.debug("handle Target: " + targetModel.getIdentifier());
-      String dbMetric = new String(
-          monitorModel.getMetric().concat("+++").concat(targetModel.getTargetType().name())
-              .concat("+++").concat(targetModel.getIdentifier()));
-      monitorModel.setMetric(dbMetric);
-      monitorModelRepository.save(monitorModel);
-      LOGGER.debug("saved MonitorModel: " + monitorModel.getMetric());
+      MonitorModel target = monitorModel;
+
+      target.setMetric(monitorModel.getMetric().concat("+++")
+          .concat(targetModel.getTargetType().name())
+          .concat("+++").concat(targetModel.getIdentifier()));
+      LOGGER.debug("dbMetric: " + target.getMetric());
+      monitorModelRepository.save(target);
+      LOGGER.debug("saved MonitorModel: " + target.getMetric());
       monitorModel.setMetric(monitorModel.getMetric().split("[+++]", 2)[0]);
-      LOGGER.debug("reset metric" + monitorModel.getMetric());
+      LOGGER.debug("reset metric " + monitorModel.getMetric());
     }
+    */
+    monitorModelRepository.save(monitorModel);
 
     return MONITOR_MODEL_CONVERTER.apply(monitorModel);
   }

--- a/monitoringagent/src/main/java/io/github/cloudiator/persistance/MonitorModel.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/persistance/MonitorModel.java
@@ -66,6 +66,10 @@ public class MonitorModel extends Model {
     return metric;
   }
 
+  public void setMetric(String metric) {
+    this.metric = metric;
+  }
+
   public List<TargetModel> getTargets() {
     return targets;
   }

--- a/monitoringagent/src/main/java/io/github/cloudiator/persistance/MonitorModelConverter.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/persistance/MonitorModelConverter.java
@@ -18,7 +18,7 @@ public class MonitorModelConverter implements OneWayConverter<MonitorModel, Doma
   public DomainMonitorModel apply(@Nullable MonitorModel monitorModel) {
     //Metric
     DomainMonitorModel result = new DomainMonitorModel()
-        .metric(monitorModel.getMetric());
+        .metric(monitorModel.getMetric().split("[+++]", 2)[0]);
     //Target
     for (TargetModel targetModel : monitorModel.getTargets()) {
       result.addTargetsItem(targetModelConverter.apply(targetModel));

--- a/monitoringagent/src/main/resources/logback.xml
+++ b/monitoringagent/src/main/resources/logback.xml
@@ -61,6 +61,7 @@
 
   <logger level="DEBUG" name="io.github.cloudiator.monitoring"/>
   <logger level="DEBUG" name="org.cloudiator.messaging.kafka"/>
+  <logger level="DEBUG" name="io.github.cloudiator.persistance"/>
 
   <root level="WARN">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
changed DB Setup:
in DB the monitormetric is now composed of monitormetric + targettype +targetID :
* so a monitormetric can be used on several nodes or processes
* a monitor with multiple target is saved separately for each target
* the monitortarget is saved as tag by creation  