### PR TITLE
syncronized handling

### DIFF
--- a/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/MonitorQueueController.java
+++ b/monitoringagent/src/main/java/io/github/cloudiator/monitoring/domain/MonitorQueueController.java
@@ -70,7 +70,7 @@ public class MonitorQueueController {
     return queueMap.size();
   }
 
-  public boolean handleMonitorRequest(String nodeId, DomainMonitorModel domainMonitorModel) {
+  public synchronized boolean handleMonitorRequest(String nodeId, DomainMonitorModel domainMonitorModel) {
 
     LOGGER.debug("QueueController handling Monitor");
     Queue<DomainMonitorModel> usedQueue;


### PR DESCRIPTION
uses synchronized for the queue check,
so only one queue would be created